### PR TITLE
Make @types/node a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,10 @@
     "type": "git",
     "url": "http://github.com/httptoolkit/httpolyglot.git"
   },
-  "dependencies": {
-    "@types/node": "^16.7.10"
-  },
   "devDependencies": {
     "@types/chai": "^4.2.21",
     "@types/mocha": "^9.0.0",
+    "@types/node": "^16.7.10",
     "chai": "^4.3.4",
     "mocha": "^9.1.1",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
Since local packages that are written with TypeScript commonly have their own @types/node in devDependencies anyway, I propose to move them into devDependencies. Since dependencies will be installed in production environments, the current approach makes the dependency tree unnecessarily bloated, at least in my opinion.