### PR TITLE
Remove `boundListener`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ export class Server extends net.Server {
 
     // Create subservers for each supported protocol:
     this._httpServer = new http.Server(boundListener);
-    this._http2Server = http2.createServer({}, boundListener);
+    this._http2Server = http2.createServer({}, boundListener as any as Http2Listener);
 
     if (tlsServer) {
       // If we've been given a preconfigured TLS server, we use that directly, and

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,13 +76,9 @@ export class Server extends net.Server {
       requestListener = listener!;
     }
 
-    // We bind the request listener, so 'this' always refers to us, not each subserver.
-    // This means 'this' is consistent (and this.close() works).
-    const boundListener = requestListener.bind(this);
-
     // Create subservers for each supported protocol:
-    this._httpServer = new http.Server(boundListener);
-    this._http2Server = http2.createServer({}, boundListener as any as Http2Listener);
+    this._httpServer = new http.Server(requestListener);
+    this._http2Server = http2.createServer({}, requestListener);
 
     if (tlsServer) {
       // If we've been given a preconfigured TLS server, we use that directly, and

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,9 +76,15 @@ export class Server extends net.Server {
       requestListener = listener!;
     }
 
+    // We bind the request listener, so 'this' always refers to us, not each subserver.
+    // This means 'this' is consistent (and this.close() works).
+    // Use `Function.prototype.bind` directly as frameworks like Express generate 
+    // methods from `http.METHODS`, and `BIND` is an included HTTP method.
+    const boundListener = Function.prototype.bind.call(requestListener, this);
+
     // Create subservers for each supported protocol:
-    this._httpServer = new http.Server(requestListener);
-    this._http2Server = http2.createServer({}, requestListener);
+    this._httpServer = new http.Server(boundListener);
+    this._http2Server = http2.createServer({}, boundListener);
 
     if (tlsServer) {
       // If we've been given a preconfigured TLS server, we use that directly, and


### PR DESCRIPTION
Following up from https://github.com/pillarjs/path-to-regexp/issues/333, it appears some users are passing Express.js instances directly to this library. Express.js has a method called `bind` (from node.js `require('http').METHODS`) so this is not the native method. For a very long time this has basically been a noop because it does a `return this`, but recently an implicit string coercion was removed for all the `app[METHODS]` methods, so this line now causes an error.

Opening to start a discussion since issues are disabled.